### PR TITLE
Use editorLangId, not resourceLangId

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,23 +29,23 @@
     "menus": {
       "editor/context": [
         {
-          "when": "resourceLangId == html",
+          "when": "editorLangId == html",
           "command": "linz.tpl"
         },
         {
-          "when": "resourceLangId == scss",          
+          "when": "editorLangId == scss",          
           "command": "linz.cssImg"
         },
         {
-          "when": "resourceLangId == css",          
+          "when": "editorLangId == css",          
           "command": "linz.cssImg"
         },
         {
-          "when": "resourceLangId == less",          
+          "when": "editorLangId == less",          
           "command": "linz.cssImg"
         },
         {
-          "when": "resourceLangId == vue",          
+          "when": "editorLangId == vue",          
           "command": "linz.cssImg"
         }
       ]


### PR DESCRIPTION
By filtering context menu (and command palette) items using editorLangId
instead of resourceLangId, they can also be used in unsaved buffers in
the appropriate language mode.

As this extensions' commands seem to interact with the buffer content,
but not with the file system this approach seems reasonable to me here.

See https://github.com/Microsoft/vscode/issues/26873